### PR TITLE
Use OS-aware calls to /etc/init.d/supervisor[d]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,7 +195,7 @@ class supervisor(
     ensure     => $service_ensure_real,
     enable     => $service_enable,
     hasrestart => true,
-    restart    => '/etc/init.d/supervisor stop && sleep 10 && /etc/init.d/supervisor start',
+    restart    => "/etc/init.d/${supervisor::params::system_service} stop && sleep 10 && /etc/init.d/${supervisor::params::system_service} start",
     require    => File[$supervisor::params::conf_file],
   }
 }


### PR DESCRIPTION
This patch fixes RHEL/CentOS/Fedora support by using the Puppet configuration variable from manifests/params.pp to call correct supervisord init script.

Previously, puppet-supervisor hardcoded `/etc/init.d/supervisor` as the init script but on RHEL/CentOS/Fedora the init script is actually called `/etc/init.d/supervisord` (note the trailing "d").
