### PR TITLE
Enable Amazon Linux support when running on EC2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class supervisor::params {
       $system_service = 'supervisor'
       $package        = 'supervisor'
     }
-    'centos','fedora','redhat': {
+    'centos','fedora','redhat','Amazon': {
       $conf_file      = '/etc/supervisord.conf'
       $conf_dir       = '/etc/supervisord.d'
       $system_service = 'supervisord'


### PR DESCRIPTION
This patch enables the use of puppet-supervisor on Amazon Linux AMI images on EC2.  Amazon Linux is compatible to the RHEL family.
